### PR TITLE
user endpoint fix (small update)

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -6,7 +6,7 @@ import knex from "./database_client.js";
 
 import register from "./routers/register.js";
 import login from "./routers/login.js";
-import userRoute from "./routers/user.js";
+import user from "./routers/user.js";
 
 const app = express();
 app.use(cors());
@@ -16,7 +16,7 @@ const apiRouter = express.Router();
 app.use("/api", apiRouter);
 apiRouter.use("/register", register);
 apiRouter.use("/login", login);
-apiRouter.use("/user", userRoute);
+apiRouter.use("/user", user);
 
 apiRouter.get("/", async (req, res) => {
   res.json("This is welcoming page of FONA Api");

--- a/api/src/routers/login.js
+++ b/api/src/routers/login.js
@@ -11,13 +11,13 @@ login.post("/", async (req, res) => {
   const { email, password } = req.body;
   // Checking if we get the username and password
   if (!email || !password) {
-    return res.status(400).send("Email and password required");
+    return res.status(400).json({ message: "Email and password are required" });
   }
   try {
-    const user = await knex("user").where({ email }).first();
+    const user = await knex("users").where({ email }).first();
     //Checking if user exist
     if (!user) {
-      return res.status(401).send("Invalid email or password");
+      return res.status(401).json({ message: "Invalid email or password" });
     }
 
     // Comparing hashed password from db with the provided password
@@ -38,11 +38,10 @@ login.post("/", async (req, res) => {
       res.status(200).json({ userInfo: userInfo, token });
     } else {
       // Invalid password
-      res.status(401).send("Invalid password");
+      res.status(401).json({ message: "Invalid password" });
     }
   } catch (error) {
-    console.error("Error logging in: ", error);
-    res.status(500).send("Error logging in: " + error.message);
+    res.status(500).json({ error: `Error logging in: ${error.message}` });
   }
 });
 

--- a/api/src/routers/register.js
+++ b/api/src/routers/register.js
@@ -8,13 +8,13 @@ const register = express.Router();
 register.post("/", async (req, res) => {
   const { email, password, first_name, last_name } = req.body;
   if (!email || !password || !first_name || !last_name) {
-    return res.status(400).send("all fields required");
+    return res.status(400).json({ message: "All fields are required" });
   }
   try {
     // Checking if the username already exists
     const existedUser = await knex("user").where({ email }).first();
     if (existedUser) {
-      return res.status(400).send("Username already exists");
+      return res.status(400).json({ message: "Email already in use" });
     }
     // Hashing the password before save in dB
     const saltRounds = 10;
@@ -25,10 +25,9 @@ register.post("/", async (req, res) => {
       last_name: last_name,
       password_hash: hashedPassword,
     });
-    res.status(201).send("registered succesfully");
+    res.status(201).json({ message: "Registration was successful" });
   } catch (error) {
-    console.log("Error registering the user");
-    res.status(500).send("Error registrariton: " + error.message);
+    res.status(500).json({ error: `Registration error: ${error.message}` });
   }
 });
 

--- a/api/src/routers/user.js
+++ b/api/src/routers/user.js
@@ -2,7 +2,7 @@ import express from "express";
 import jwt from "jsonwebtoken";
 import knex from "../database_client.js";
 
-const userRoute = express.Router();
+const user = express.Router();
 // JWT's secret Key
 const SECRET_KEY = process.env.JWT_SECRET;
 
@@ -10,7 +10,6 @@ const SECRET_KEY = process.env.JWT_SECRET;
 function authenticateToken(req, res, next) {
   const tokenAuth = req.header("Authorization")?.split(" ")[1];
   if (!tokenAuth) return res.status(401).json({ message: "Unauthorized" });
-
   jwt.verify(tokenAuth, SECRET_KEY, (err, userInfo) => {
     if (err) return res.status(403).json({ message: "Forbidden" });
     req.userInfo = userInfo;
@@ -18,13 +17,12 @@ function authenticateToken(req, res, next) {
   });
 }
 // The endpoint is for getting user information in a safe way
-userRoute.get("/me", authenticateToken, async (req, res) => {
+user.get("/me", authenticateToken, async (req, res) => {
   const requestedId = req.userInfo.userId;
   const userData = await knex("user").where({ user_id: requestedId }).first();
   //if user not found
   if (!userData) return res.status(404).json({ message: "User not found" });
-  // If user is found and authenticated then returning the user data
   return res.status(200).json({ userData });
 });
 
-export default userRoute;
+export default user;

--- a/api/src/routers/user.js
+++ b/api/src/routers/user.js
@@ -18,8 +18,7 @@ function authenticateToken(req, res, next) {
 }
 // The endpoint is for getting user information in a safe way
 user.get("/me", authenticateToken, async (req, res) => {
-  const requestedId = req.userInfo.userId;
-  const userData = await knex("user").where({ user_id: requestedId }).first();
+  const userData = await knex("user").where({ user_id: req.userInfo.userId }).first();
   //if user not found
   if (!userData) return res.status(404).json({ message: "User not found" });
   return res.status(200).json({ userData });

--- a/api/src/routers/user.js
+++ b/api/src/routers/user.js
@@ -17,20 +17,12 @@ function authenticateToken(req, res, next) {
     next();
   });
 }
-
-userRoute.get("/:id", authenticateToken, async (req, res) => {
-  const requestedId = parseInt(req.params.id);
-  // Check if the authenticated user matches the requested user ID
-
-  if (req.userInfo.userId !== requestedId) {
-    return res.status(403).json({ message: "Access denied" });
-  }
-
+// The endpoint is for getting user information in a safe way
+userRoute.get("/me", authenticateToken, async (req, res) => {
+  const requestedId = req.userInfo.userId;
   const userData = await knex("user").where({ user_id: requestedId }).first();
-
   //if user not found
   if (!userData) return res.status(404).json({ message: "User not found" });
-
   // If user is found and authenticated then returning the user data
   return res.status(200).json({ userData });
 });

--- a/api/src/routers/user.js
+++ b/api/src/routers/user.js
@@ -25,15 +25,14 @@ userRoute.get("/:id", authenticateToken, async (req, res) => {
   if (req.userInfo.userId !== requestedId) {
     return res.status(403).json({ message: "Access denied" });
   }
-  console.log(req.userInfo);
-  const userData = await knex("user").select("*");
-  const user = userData.find((u) => u.user_id === requestedId);
+
+  const userData = await knex("user").where({ user_id: requestedId }).first();
 
   //if user not found
-  if (!user) return res.status(404).json({ message: "User not found" });
+  if (!userData) return res.status(404).json({ message: "User not found" });
 
   // If user is found and authenticated then returning the user data
-  return res.status(200).json({ user });
+  return res.status(200).json({ userData });
 });
 
 export default userRoute;


### PR DESCRIPTION
## Description


- Unnecesarry functionality prevented. 
- Same functionality with less code

---

## Changes Made


- **Backend:**  As a result of our recent discussions, we removed unnecessary code to simplify the codebase. The api/user/:id endpoint has also been adjusted to api/user/me for a more intuitive experience.

---



## Testing Steps


**Backend:** If latest fetch has been done the route for /api/user/me can be tested by postman, requirements for testing the api :

Sending get request to the localhost:3001/api/user/me endpoint(if you running locally) with header; key : `Authorization` value : `Bearer <token> `


---


