### PR TITLE
[FIX] Update Application Status Handling

### DIFF
--- a/api/src/controllers/publicApiController.js
+++ b/api/src/controllers/publicApiController.js
@@ -2,13 +2,15 @@ import knex from '../database_client.js'
 
 export const getApplicationStatuses = async (req, res) => {
   try {
-    // Fetch predefined values for status
-    const rows = await knex('application').distinct('status')
+    // Get all possible values from application_status enum type as separate rows
+    const { rows } = await knex.raw(`
+      SELECT unnest(enum_range(NULL::application_status)) as status;
+    `)
 
     // Mapping the raw statuses to the format that will be used in frontend
     const statuses = rows.map((row) => ({
       value: row.status,
-      label: row.status.charAt(0).toUpperCase() + row.status.slice(1), // Capitalizing the first letter for the label
+      label: row.status.charAt(0).toUpperCase() + row.status.slice(1),
     }))
 
     // Returning the response with the statuses array

--- a/frontend/app/user/ApplicationAddForm.js
+++ b/frontend/app/user/ApplicationAddForm.js
@@ -206,7 +206,7 @@ export default function AddApplicationForm({ openModal, onClose }) {
               <Controller
                 name="status"
                 control={control}
-                defaultValue={statuses.length > 0 ? statuses[4].value : ''}
+                defaultValue={statuses.length > 0 ? statuses[0].value : ''}
                 render={({ field }) => (
                   <Select
                     labelId="status-label"


### PR DESCRIPTION
# [FIX] Update Application Status Handling


---

## Description

This PR improves the handling of application statuses by fetching them directly from the database enum type instead of existing applications, and updates the default status in the application form.
	•	Solves the issue of missing status options when no applications exist in the database
	•	Ensures consistent status options regardless of existing data
	•	Updates default status selection to start with 'saved' instead of 'rejected'

---

## Changes Made

- Backend:
	▪	Modified getApplicationStatuses in publicApiController.js to use PostgreSQL enum_range
	▪	Replaced query from application table with direct enum type query
- Frontend:
	▪	Updated ApplicationAddForm.js default status value
	▪	Changed default status from index 4 (rejected) to index 0 (saved)




---

## Screenshots (if applicable)

![screencapture-localhost-3000-user-2024-11-14-22_05_51](https://github.com/user-attachments/assets/2aa2c7e7-ce40-47d6-ae5f-b6ca2a00ffe8)


---

## Testing Steps

Frontend:
	▪	Open application add form
	▪	Verify status dropdown shows all options
	▪	Confirm default status is 'saved'
	▪	Test status selection functionality