### PR TITLE
fix: Add application logic

### DIFF
--- a/api/src/utils/getOrCreateCompanyId.js
+++ b/api/src/utils/getOrCreateCompanyId.js
@@ -9,7 +9,9 @@ export const getOrCreateCompanyId = async (companyName, user_id) => {
     const existingCompany = await knex('company')
       .whereRaw('LOWER(name) = ?', trimmedCompanyName.toLowerCase())
       .first()
-    if (existingCompany) {
+
+    // Checking if the company name exists and if it does, whether it belongs to the same user
+    if (existingCompany && existingCompany.user_id === user_id) {
       company_id = existingCompany.company_id
       return company_id
     } else {


### PR DESCRIPTION
# Adding Application Logic Change 

- Logic has been added to check whether the company name input is from the same user.


## Description

- What problem does this PR solve?

    - Before this change, different users could not add the same company name because the system used the company name as a unique identifier. This caused issues when multiple users wanted to register the same company name.

- What is the impact of the change?
    - This update allows multiple users to add the same company name, as each user is now assigned a unique company ID, ensuring no conflicts when the same company name is used by different users.

---

## Changes Made

List the main changes in this pull request. Describe what was added, modified, or removed.


- **Backend:** Modified logic to allow multiple users to add the same company name by checking for user-specific company IDs rather than global company name uniqueness.

---

## Screenshots (if applicable)

![fix ss](https://github.com/user-attachments/assets/bf6e5435-2997-4784-b63a-6db719d6e5bd)


---

## Testing Steps

Describe how to test this feature or bug fix.

1. **Frontend:** Test the add application form with multiple users trying to create companies with the same name. Ensure each company is assigned a unique company ID.
2. **Backend:** Test the API endpoints related to company creation. Ensure that users can create companies with the same name but with different company IDs.

---

