### PR TITLE
Freeze the object of .env file

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -14,7 +14,7 @@ const env = envalid.cleanEnv(process.env, {
   JWT_EXPIRY_IN_SECONDS: envalid.num({ default: 3600, min: 60 }),
 })
 
-export default {
+export default Object.freeze({
   ...env,
   JWT_EXPIRY_WITH_UNIT: `${env.JWT_EXPIRY_IN_SECONDS}s`,
-}
+})

--- a/api/src/utils/auth.js
+++ b/api/src/utils/auth.js
@@ -6,8 +6,6 @@ import config from '../config.js'
 const SECRET_KEY = config.JWT_SECRET
 
 export const generateAuthResponse = (user) => {
-  const expireTime = config.JWT_EXPIRY_WITH_UNIT
-
   if (!SECRET_KEY) {
     throw new Error('JWT_SECRET is not defined in environment variables')
   }
@@ -21,7 +19,7 @@ export const generateAuthResponse = (user) => {
   const jti = uuidv4()
 
   const token = jwt.sign({ userId: user.user_id, jti: jti }, SECRET_KEY, {
-    expiresIn: expireTime,
+    expiresIn: config.JWT_EXPIRY_WITH_UNIT,
   })
 
   return { userInfo, token }


### PR DESCRIPTION
## Description

This pull request refactors the code to improve the handling of JWT configuration by making the environment configuration immutable and simplifying the use of JWT expiry details.

**Problem Solved:**

The existing implementation did not fully utilize immutability for configuration, which could lead to accidental modification of environment variables during runtime. Additionally, there were redundant variables in the auth.js file for JWT expiry.


---

## Changes Made

1. Made the exported configuration object immutable using Object.freeze.
2. Removed the local expireTime variable and directly accessed config.JWT_EXPIRY_WITH_UNIT.

---
