### PR TITLE
[UPDATE] Allow Homepage Access for Authenticated Users

### DIFF
--- a/frontend/components/RouteGuard.js
+++ b/frontend/components/RouteGuard.js
@@ -5,7 +5,7 @@ import { useEffect } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import Loader from './ui/Loader'
 
-const publicPaths = ['/', '/login', '/register']
+const publicPaths = ['/login', '/register']
 
 export default function RouteGuard({ children }) {
   const { isLoggedIn, isLoading } = useAuth()


### PR DESCRIPTION
# [UPDATE] Allow Homepage Access for Authenticated Users

---

## Description

This PR modifies the RouteGuard component to allow authenticated users to access the Homepage while maintaining protection for auth pages.

Problem: Homepage was incorrectly blocked for authenticated users
Impact: Improves accessibility by allowing all users to view the Homepage

---

## Changes Made

- Removed Homepage ('/') from restricted paths

---

## Testing Steps

Logged In User:
- Should now be able to access Homepage ('/')