### PR TITLE
# [UI] Update ApplicationHeader, InterviewCard, JobInfo, and FormatDate Components

### DIFF
--- a/frontend/app/applications/[id]/ApplicationHeader.js
+++ b/frontend/app/applications/[id]/ApplicationHeader.js
@@ -89,7 +89,11 @@ export default function ApplicationHeader() {
               {application.company_location}
             </Typography>
           ) : (
-            <Typography variant="overline" color="comment.main">
+            <Typography
+              variant="overline"
+              color="comment.main"
+              sx={{ height: '24px' }}
+            >
               location
             </Typography>
           )}
@@ -109,7 +113,12 @@ export default function ApplicationHeader() {
               {application.company_website}
             </Link>
           ) : (
-            <Typography variant="overline" component="div" color="comment.main">
+            <Typography
+              variant="overline"
+              component="div"
+              color="comment.main"
+              sx={{ height: '24px' }}
+            >
               Website
             </Typography>
           )}

--- a/frontend/app/applications/[id]/ApplicationHeader.js
+++ b/frontend/app/applications/[id]/ApplicationHeader.js
@@ -4,7 +4,6 @@ import NextLink from 'next/link'
 import {
   Typography,
   Stack,
-  Link,
   Box,
   IconButton,
   Divider,
@@ -15,6 +14,7 @@ import EditIcon from '@mui/icons-material/Edit'
 import { useApplicationContext } from '@/components/Context/ApplicationContext'
 import CompanyEditForm from './forms/CompanyEditForm'
 import MenuButtonApplication from './MenuButtonApplication'
+import ExternalLink from '@/components/ui/ExternalLink'
 
 export default function ApplicationHeader() {
   const { application } = useApplicationContext()
@@ -99,23 +99,10 @@ export default function ApplicationHeader() {
           )}
 
           {application.company_website ? (
-            <Link
-              href={application.company_website}
-              target="_blank"
-              sx={{
-                display: application.company_website ? 'block' : 'none',
-                color: 'inherit',
-                textDecoration: 'none',
-                '&:hover': { textDecoration: 'underline' },
-                wordBreak: 'break-word',
-              }}
-            >
-              {application.company_website}
-            </Link>
+            <ExternalLink link={application.company_website} />
           ) : (
             <Typography
               variant="overline"
-              component="div"
               color="comment.main"
               sx={{ height: '24px' }}
             >

--- a/frontend/app/applications/[id]/tabs/InterviewCard.js
+++ b/frontend/app/applications/[id]/tabs/InterviewCard.js
@@ -1,9 +1,9 @@
 'use client'
-import { Stack, Card, Typography, Box, Chip, Link } from '@mui/material'
+import { Stack, Card, Typography, Box, Chip } from '@mui/material'
 import MenuButtonInterview from '../MenuButtonInterview'
 import { formatDateTime } from '@/utils/formatDate'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
+import ExternalLink from '@/components/ui/ExternalLink'
 
 const styles = {
   card: {
@@ -33,43 +33,6 @@ const styles = {
   },
 }
 
-const MeetingLink = ({ link }) => (
-  <Box>
-    <Link
-      href={link}
-      target="_blank"
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: 'inherit',
-        textDecoration: 'none',
-        '&:hover': { textDecoration: 'underline' },
-        wordBreak: 'break-word',
-        fontSize: '1rem',
-      }}
-    >
-      <OpenInNewIcon sx={{ fontSize: 16, marginRight: 1 }} />
-      <Typography
-        sx={{
-          fontSize: '1rem',
-          color: 'inherit',
-          textOverflow: 'ellipsis',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          maxWidth: {
-            xs: '200px',
-            sm: '300px',
-            md: '400px',
-          },
-        }}
-      >
-        {link}
-      </Typography>
-    </Link>
-  </Box>
-)
-
 export default function InterviewCard({
   interview,
   onInterviewDeleted,
@@ -78,7 +41,7 @@ export default function InterviewCard({
   const renderLocation = () => {
     if (interview.isVirtual) {
       return interview.location ? (
-        <MeetingLink link={interview.location} />
+        <ExternalLink link={interview.location} />
       ) : (
         <Typography component="p" variant="overline" color="comment.main">
           Meeting Link

--- a/frontend/app/applications/[id]/tabs/InterviewCard.js
+++ b/frontend/app/applications/[id]/tabs/InterviewCard.js
@@ -1,7 +1,7 @@
 'use client'
 import { Stack, Card, Typography, Box, Chip, Link } from '@mui/material'
 import MenuButtonInterview from '../MenuButtonInterview'
-import { formatDate } from '@/utils/formatDate'
+import { formatDateTime } from '@/utils/formatDate'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
 
@@ -126,7 +126,7 @@ export default function InterviewCard({
               width: { xs: 'auto', sm: '200px' },
             }}
           >
-            {formatDate(interview.scheduledAt)}
+            {formatDateTime(interview.scheduledAt)}
           </Typography>
           <Typography
             variant="body1"

--- a/frontend/app/applications/[id]/tabs/JobInfo.js
+++ b/frontend/app/applications/[id]/tabs/JobInfo.js
@@ -12,6 +12,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { useIsMobile } from '@/app/hooks/useIsMobile'
 import { useApplicationContext } from '@/components/Context/ApplicationContext'
 import RichText from '@/components/ui/RichText'
+import { formatDate } from '@/utils/formatDate'
 
 export default function JobInfo() {
   const { application } = useApplicationContext()
@@ -32,12 +33,87 @@ export default function JobInfo() {
     textDecoration: 'none',
     '&:hover': { textDecoration: 'underline' },
     wordBreak: 'break-word',
-    fontSize: isMobile ? '0.875rem' : '1rem',
+    fontSize: '1rem',
   }
 
   return (
     <Box sx={{ padding: 2 }}>
-      <Accordion>
+      <Accordion defaultExpanded>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="dates-content"
+          id="dates-header"
+          sx={accordionSummaryStyles}
+        >
+          Dates
+        </AccordionSummary>
+        <AccordionDetails>
+          <Stack
+            sx={{
+              justifyContent: 'start',
+              alignItems: 'start',
+              flexDirection: 'column',
+              gap: 1,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'row',
+                gap: 1,
+              }}
+            >
+              <Typography
+                variant="body1"
+                sx={{ color: 'secondary.main', minWidth: '120px' }}
+              >
+                Applied Date
+              </Typography>
+
+              {application.applied_date ? (
+                <Typography variant="body1">
+                  {formatDate(application.applied_date)}
+                </Typography>
+              ) : (
+                <Typography variant="overline" color="comment.main">
+                  date
+                </Typography>
+              )}
+            </Box>
+
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'row',
+                gap: 1,
+              }}
+            >
+              <Typography
+                variant="body1"
+                sx={{ color: 'secondary.main', minWidth: '120px' }}
+              >
+                Deadline Date
+              </Typography>
+
+              {application.deadline_date ? (
+                <Typography variant="body1">
+                  {formatDate(application.deadline_date)}
+                </Typography>
+              ) : (
+                <Typography variant="overline" color="comment.main">
+                  date
+                </Typography>
+              )}
+            </Box>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion defaultExpanded>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           aria-controls="job_link-content"
@@ -60,75 +136,6 @@ export default function JobInfo() {
               job link
             </Typography>
           )}
-        </AccordionDetails>
-      </Accordion>
-
-      <Accordion>
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="dates-content"
-          id="dates-header"
-          sx={accordionSummaryStyles}
-        >
-          Dates
-        </AccordionSummary>
-        <AccordionDetails>
-          <Stack
-            sx={{
-              justifyContent: 'start',
-              alignItems: 'center',
-              flexDirection: 'row',
-              gap: 4,
-            }}
-          >
-            <Box
-              sx={{
-                p: 0,
-              }}
-            >
-              <Typography
-                variant="body2"
-                gutterBottom
-                sx={{ color: 'secondary.main' }}
-              >
-                Applied Date
-              </Typography>
-
-              {application.applied_date ? (
-                <Typography variant={isMobile ? 'body2' : 'body1'}>
-                  {new Date(application.applied_date).toLocaleDateString(
-                    'en-GB'
-                  )}
-                </Typography>
-              ) : (
-                <Typography variant="overline" color="comment.main">
-                  no date
-                </Typography>
-              )}
-            </Box>
-
-            <Box sx={{ p: 0 }}>
-              <Typography
-                variant="body2"
-                gutterBottom
-                sx={{ color: 'secondary.main' }}
-              >
-                Deadline Date
-              </Typography>
-
-              {application.deadline_date ? (
-                <Typography variant={isMobile ? 'body2' : 'body1'}>
-                  {new Date(application.deadline_date).toLocaleDateString(
-                    'en-GB'
-                  )}
-                </Typography>
-              ) : (
-                <Typography variant="overline" color="comment.main">
-                  no date
-                </Typography>
-              )}
-            </Box>
-          </Stack>
         </AccordionDetails>
       </Accordion>
 

--- a/frontend/app/applications/[id]/tabs/JobInfo.js
+++ b/frontend/app/applications/[id]/tabs/JobInfo.js
@@ -4,19 +4,17 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Link,
   Typography,
   Stack,
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import { useIsMobile } from '@/app/hooks/useIsMobile'
 import { useApplicationContext } from '@/components/Context/ApplicationContext'
 import RichText from '@/components/ui/RichText'
 import { formatDate } from '@/utils/formatDate'
+import ExternalLink from '@/components/ui/ExternalLink'
 
 export default function JobInfo() {
   const { application } = useApplicationContext()
-  const isMobile = useIsMobile()
 
   const accordionSummaryStyles = {
     fontWeight: 600,
@@ -26,14 +24,6 @@ export default function JobInfo() {
     '& .MuiAccordionSummary-content': {
       margin: 0,
     },
-  }
-
-  const textLinkStyles = {
-    color: 'inherit',
-    textDecoration: 'none',
-    '&:hover': { textDecoration: 'underline' },
-    wordBreak: 'break-word',
-    fontSize: '1rem',
   }
 
   return (
@@ -124,13 +114,7 @@ export default function JobInfo() {
         </AccordionSummary>
         <AccordionDetails>
           {application.job_link ? (
-            <Link
-              href={application.job_link}
-              target="_blank"
-              sx={textLinkStyles}
-            >
-              {application.job_link}
-            </Link>
+            <ExternalLink link={application.job_link} />
           ) : (
             <Typography variant="overline" color="comment.main">
               job link

--- a/frontend/components/ui/ExternalLink.js
+++ b/frontend/components/ui/ExternalLink.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Stack, Typography, Link } from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+
+const ExternalLink = ({ children, link }) => (
+  <Link
+    href={link}
+    target="_blank"
+    sx={{
+      color: 'text.primary',
+      textDecoration: 'none',
+      '&:hover': { textDecoration: 'underline' },
+      wordBreak: 'break-word',
+      fontSize: '1rem',
+    }}
+  >
+    <Stack
+      sx={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'start',
+      }}
+    >
+      <OpenInNewIcon
+        sx={{ fontSize: 16, marginRight: 1, color: 'text.primary' }}
+      />
+      <Typography
+        sx={{
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          maxWidth: {
+            xs: '200px',
+            sm: '300px',
+            md: '400px',
+          },
+        }}
+      >
+        {children || link}
+      </Typography>
+    </Stack>
+  </Link>
+)
+export default ExternalLink

--- a/frontend/utils/formatDate.js
+++ b/frontend/utils/formatDate.js
@@ -12,7 +12,7 @@ export const formatRelativeTime = (date) => {
   return `${Math.round(diffDays / 365)}y ago`
 }
 
-export const formatDate = (dateString) => {
+export const formatDateTime = (dateString) => {
   const date = new Date(dateString)
   return date.toLocaleString('en-US', {
     weekday: 'short',
@@ -22,5 +22,15 @@ export const formatDate = (dateString) => {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
+  })
+}
+
+export const formatDate = (dateString) => {
+  const date = new Date(dateString)
+  return date.toLocaleString('en-US', {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
   })
 }


### PR DESCRIPTION
# [UI] Update ApplicationHeader, InterviewCard, JobInfo, and FormatDate Components

---

## Description

This PR addresses UI updates and refactoring in the `ApplicationHeader`, `InterviewCard`, `JobInfo`, and `formatDate` components to improve consistency and readability. Key changes include updates to conditional rendering of location and website, layout adjustments, and a fix to the `formatDate` function for better date formatting.

- **ApplicationHeader**: Adjusted rendering of location and website, ensuring better presentation.
- **InterviewCard**: Minor UI adjustments.
- **JobInfo**: Cleaned up and optimized the date formatting and layout.
- **formatDate**: Refined the date formatting function for improved output.

---

## Changes Made

- **Frontend**:
  - **ApplicationHeader**:
    - Updated the conditional rendering for location and website, with improved fallback UI for missing values.
  - **InterviewCard**:
    - Fixed rendering issues in the date display for interviews.
  - **JobInfo**:
    - Optimized the date display for `applied_date` and `deadline_date`.
    - Cleaned up redundant UI components and improved the use of Material UI components like `Accordion` for better user experience.
  - **formatDate**:
    - Refined the `formatDate` function to provide consistent date formatting across the app.

---

## Screenshots (if applicable)
![Screenshot_8](https://github.com/user-attachments/assets/aa6f9b2a-69eb-4e18-ac7c-8034c35b3635)
![Screenshot_7](https://github.com/user-attachments/assets/0dec3f7c-cf1f-4688-a174-2c116a8949fd)
---

## Testing Steps

1. **Frontend**:
   - Test the UI rendering in `ApplicationHeader` to ensure proper fallback for location and website when missing.
   - Check the date formatting in `InterviewCard` and `JobInfo` to ensure dates display correctly.
   - Confirm that the application information (location, website, dates) appears as expected across different scenarios (with and without data).
2. **Backend**:
   - No backend changes in this PR.
